### PR TITLE
Update node14

### DIFF
--- a/quiz/nodejs/nodejs.Dockerfile
+++ b/quiz/nodejs/nodejs.Dockerfile
@@ -1,4 +1,4 @@
-# base Node.js LTS image
+# base Node.js v14 image
 FROM node:14-alpine
 
 # environment variables

--- a/quiz/nodejs/nodejs.Dockerfile
+++ b/quiz/nodejs/nodejs.Dockerfile
@@ -1,5 +1,5 @@
 # base Node.js LTS image
-FROM node:lts-alpine
+FROM node:14-alpine
 
 # environment variables
 ENV NODE_ENV=production

--- a/quiz/nodejs/package.json
+++ b/quiz/nodejs/package.json
@@ -4,15 +4,15 @@
   "description": "A web quiz implemented with Docker Node.js, MongoDB, and NGINX containers",
   "main": "index.js",
   "scripts": {
-    "build:html": "pug -O ./src/html/data.json ./src/html/ -o ./static/",
+    "build:htm": "pug -O ./src/html/data.json ./src/html/ -o ./static/",
     "build:css": "postcss src/css/main.css -o static/css/main.css --no-map",
-    "build:js": "rollup --config",
-    "build": "npm run build:html && npm run build:css && npm run build:js",
-    "watch:html": "pug -O ./src/html/data.json ./src/html/ -o ./static/ --pretty -w",
-    "watch:css": "postcss src/css/main.css -o static/css/main.css -w",
-    "watch:js": "rollup --config --sourcemap inline --watch --no-watch.clearScreen",
-    "watch:node": "nodemon --trace-warnings --inspect=0.0.0.0:9229 ./index.js",
-    "debug": "runco watch:*",
+    "build:es6": "rollup --config",
+    "build": "npm run build:htm && npm run build:css && npm run build:es6",
+    "watch:htm": "pug -O ./src/html/data.json ./src/html/ -o ./static/ --pretty -w",
+    "watch:css": "postcss ./src/css/main.css -o ./static/css/main.css --map --watch --poll --verbose",
+    "watch:es6": "rollup --config --sourcemap inline --watch --no-watch.clearScreen",
+    "watch:app": "nodemon --trace-warnings --inspect=0.0.0.0:9229 ./index.js",
+    "debug": "concurrently 'npm:watch:*'",
     "start": "npm run build && node ./index.js"
   },
   "author": "Craig Buckler",
@@ -21,16 +21,17 @@
     "cssnano": "^4.1.10",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
-    "mongodb": "^3.5.8",
-    "node-fetch": "^2.6.0",
-    "postcss-cli": "^7.1.1",
-    "postcss-import": "^12.0.1",
+    "mongodb": "^3.6.2",
+    "node-fetch": "^2.6.1",
+    "postcss": "^8.1.4",
+    "postcss-cli": "^8.0.0",
+    "postcss-import": "^13.0.0",
     "pug-cli": "^1.0.0-alpha6",
-    "rollup": "^2.15.0",
-    "rollup-plugin-terser": "^6.1.0"
+    "rollup": "^2.28.2",
+    "rollup-plugin-terser": "^7.0.2"
   },
   "devDependencies": {
-    "nodemon": "^2.0.4",
-    "runco": "^2.0.0"
+    "concurrently": "^5.3.0",
+    "nodemon": "^2.0.6"
   }
 }

--- a/quiz/nodejs/rollup.config.js
+++ b/quiz/nodejs/rollup.config.js
@@ -3,6 +3,11 @@ import { terser } from 'rollup-plugin-terser';
 
 export default {
   input: './src/js/main.js',
+  watch: {
+    chokidar: {
+      usePolling: true
+    }
+  },
   output: {
     file: './static/js/main.js',
     format: 'es',


### PR DESCRIPTION
Updates

* uses Node.js 14 rather than LTS which changes over time
* Node module update
* replaces `runco` with the Node.js 14 compatible `concurrently` to run npm scripts in parallel.
* uses legacy polling in PostCSS and Rollup.js configuration which works on Alpine.